### PR TITLE
broken camera tween

### DIFF
--- a/example_src/town_scene.cpp
+++ b/example_src/town_scene.cpp
@@ -10,7 +10,7 @@ namespace suicune
     TownScene::TownScene(Game &game)
         : PlayScene(game)
     {
-        camera.zoom = 4.0f;
+        camera.get_ray_camera().zoom = 4.0f;
 
         auto tilemap_spritesheet = define_spritesheet("res/sprites/tilesheet.png", 16, 16);
         std::vector<std::vector<int>>
@@ -38,7 +38,7 @@ namespace suicune
         player->set_bound_box_dimensions(8, 4);
         player->set_bound_box_offset(4, 12);
         player->play_animation("still");
-        camera.target = player->get_position();
+        camera.set_target(player->get_position());
 
         // tree spritesheet (shared asset)
         auto tree_spritesheet = define_spritesheet("res/sprites/tree.png", 16, 32);
@@ -71,6 +71,12 @@ namespace suicune
                                     player->tween_to({50, 50}, 2.0f); });
         }
 
+        if (IsKeyPressed(KEY_O))
+        {
+            camera.tween_to({100, 100}, 2.0f, [this]()
+                            { this->camera.tween_to(this->player->get_position(), 2.0f); });
+        }
+
         if (player->is_movement_stopped())
             return;
         if (player->get_current_direction() == RIGHT)
@@ -83,12 +89,13 @@ namespace suicune
             player->play_animation("walk_down");
         else
             player->play_animation("still");
+
+        center_on_player();
     }
 
     void TownScene::draw()
     {
         PlayScene::draw();
-        center_on_player();
-    }
+        }
 
 }

--- a/suicune_src/interactable.cpp
+++ b/suicune_src/interactable.cpp
@@ -77,7 +77,7 @@ namespace suicune
         {
             // Assuming `GetScreenToWorld2D`, `GetMousePosition`, `CheckCollisionPointRec`, and `IsMouseButtonPressed`
             // are functions provided by an external library, e.g., Raylib.
-            Vector2 mouse_pos_world = GetScreenToWorld2D(GetMousePosition(), scene->get_camera());
+            Vector2 mouse_pos_world = GetScreenToWorld2D(GetMousePosition(), scene->get_camera().get_ray_camera());
             if (CheckCollisionPointRec(mouse_pos_world, {x, y, (float)width, (float)height}))
             {
                 if (hoverable)

--- a/suicune_src/menu_scene.cpp
+++ b/suicune_src/menu_scene.cpp
@@ -118,7 +118,7 @@ namespace suicune
 
     void MenuScene::draw()
     {
-        Scene::setup_draw();
+        Scene::setup_draw_screen();
 
         const auto &items = get_items();
 

--- a/suicune_src/play_scene.cpp
+++ b/suicune_src/play_scene.cpp
@@ -40,7 +40,7 @@ namespace suicune
 
     void PlayScene::draw()
     {
-        Scene::setup_draw();
+        Scene::setup_draw_world();
 
         if (tilemap)
             tilemap->draw();
@@ -182,7 +182,8 @@ namespace suicune
         if (!entity)
             return;
 
-        camera.target = Vector2Add(entity->get_position(), Vector2{entity->get_width() / 2.0f, entity->get_height() / 2.0f});
+        camera.set_target(Vector2Add(entity->get_position(), Vector2{entity->get_width() / 2.0f, entity->get_height() / 2.0f}));
+        // camera.get_ray_camera().target = Vector2Add(entity->get_position(), Vector2{entity->get_width() / 2.0f, entity->get_height() / 2.0f});
     }
 
     void PlayScene::center_on_player()

--- a/suicune_src/scene.hpp
+++ b/suicune_src/scene.hpp
@@ -4,6 +4,7 @@
 #include "spritesheet.hpp"
 #include "util.hpp"
 #include "game.hpp"
+#include "scene_camera.hpp"
 
 namespace suicune
 {
@@ -23,16 +24,20 @@ namespace suicune
 
         Game &get_game();
 
-        Camera2D &get_camera();
+        SceneCamera &get_camera();
 
         void shake(float strength, float duration);
 
     protected:
         Game &game;
-        Camera2D camera;
+        SceneCamera camera;
 
-        void setup_draw();
+        void setup_draw_world();  // begins shader (optional) + BeginMode2D
+        void setup_draw_screen(); // begins shader (optional) + NO BeginMode2D
+        void setup_scene_shader();
         void cleanup_draw();
+
+        bool mode2d_active = false;
 
         bool transitioning_scene = false;
 

--- a/suicune_src/scene_camera.cpp
+++ b/suicune_src/scene_camera.cpp
@@ -1,0 +1,72 @@
+#include "scene_camera.hpp"
+
+namespace suicune
+{
+
+    Camera2D &SceneCamera::get_ray_camera()
+    {
+        return camera;
+    }
+
+    void SceneCamera::update(float dt)
+    {
+        // if (!tween.active && x == 0.0f && y == 0.0f)
+        // {
+        //     x = camera.target.x;
+        //     y = camera.target.y;
+        // }
+
+        if (tween.active)
+        {
+            Vector2 p;
+            step_tween(tween, dt, p);
+            x = p.x;
+            y = p.y;
+        }
+
+        camera.target = {x, y};
+    }
+
+    void SceneCamera::set_target(Vector2 t)
+    {
+        x = t.x;
+        y = t.y;
+        camera.target = t;
+    }
+
+    Vector2 SceneCamera::get_target() const
+    {
+        return {x, y};
+    }
+
+    void SceneCamera::tween_to(Vector2 target, float duration)
+    {
+        tween.active = true;
+        tween.start = Vector2{x, y};
+        tween.target = target;
+        tween.duration = duration;
+        tween.elapsed = 0.0f;
+        tween.stop_movement = true;
+    }
+
+    void SceneCamera::tween_to(Vector2 target, float duration, std::function<void()> on_finished)
+    {
+        tween_to(target, duration);
+        tween.on_finished = std::move(on_finished);
+    }
+
+    bool SceneCamera::is_tweening() const
+    {
+        return tween.active;
+    }
+
+    void SceneCamera::cancel_tween()
+    {
+        tween.active = false;
+    }
+
+    bool SceneCamera::does_tween_stop_movement()
+    {
+        return tween.stop_movement;
+    }
+}

--- a/suicune_src/scene_camera.hpp
+++ b/suicune_src/scene_camera.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "raylib.h"
+#include "util.hpp"
+
+namespace suicune
+{
+
+    class SceneCamera
+    {
+    public:
+        float x;
+        float y;
+
+        Camera2D &get_ray_camera();
+
+        void update(float dt);
+
+        void set_target(Vector2 t);
+        Vector2 get_target() const;
+
+        void tween_to(Vector2 target, float duration);
+        void tween_to(Vector2 target, float duration, std::function<void()> on_finished);
+        bool is_tweening() const;
+        void cancel_tween();
+        bool does_tween_stop_movement();
+
+    private:
+        Camera2D camera;
+
+        Tween tween;
+    };
+}


### PR DESCRIPTION
probably not the right approach

the management between a scene camera and the targets + attempted abstraction is unecessary.

have each scene manage a `Tween camera_tween` and if the tween isn't active defer to current logic..

twas an attempt